### PR TITLE
Fix frame index going out of range

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -78,7 +78,8 @@ function love.keypressed(key)
 end
 
 local function pickFrameIndex(x)
-    return math.floor(x / lg.getWidth() * #frames) + 1
+    local index = math.floor(x / lg.getWidth() * (#frames - 1)) + 1
+    return math.min(math.max(index, 1), #frames)
 end
 
 function love.mousepressed(x, y, button)


### PR DESCRIPTION
This could go below 1 and above the maximum number of frames when selecting at the far edges of the graph.