### PR TITLE
Fixed memory flamegraph not drawing correctly

### DIFF
--- a/draw.lua
+++ b/draw.lua
@@ -367,7 +367,7 @@ function love.draw()
     if node then
         local hovered = renderSubGraph(node, 0, graphY - const.infoLineHeight, winW,
             flameGraphFuncs[draw.flameGraphType],
-            flameGraphType == "memory" or not frames.current.index)
+            draw.flameGraphType == "memory" or not frames.current.index)
         if hovered then
             infoLine = hovered.name .. " " .. getNodeString(hovered)
 


### PR DESCRIPTION
It was drawing all of the nodes overlapping each other.
